### PR TITLE
Fixed deprecation warning and added missing dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 
 ## Uncomment this if the package has a setup.py. This macro ensures
@@ -86,7 +86,6 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS message_runtime roscpp
-  DEPENDS eigen
 )
 
 ###########
@@ -94,7 +93,7 @@ catkin_package(
 ###########
 
 include_directories(include ${catkin_INCLUDE_DIRS})
-include_directories(include ${Eigen_INCLUDE_DIRS})
+include_directories(include ${EIGEN3_INCLUDE_DIRS})
 
 add_library(line src/line.cpp)
 target_link_libraries(line ${catkin_LIBRARIES})

--- a/package.xml
+++ b/package.xml
@@ -8,6 +8,7 @@
   <maintainer email="m.gallant@queensu.ca">Marc Gallant</maintainer>
   <license>BSD</license>
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>eigen</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>cmake_modules</build_depend>
+  <build_depend>visualization_msgs</build_depend>
   <run_depend>rospy</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>


### PR DESCRIPTION
In ROS kinetic there was a deprecation message stating:
`Change instances of find_package(Eigen) to find_package(Eigen3).`

Also the package did not depend on visualization_msgs which it is using.