### PR TITLE
bug fix in  line_extraction.cpp

### DIFF
--- a/src/line_extraction.cpp
+++ b/src/line_extraction.cpp
@@ -45,8 +45,12 @@ void LineExtraction::extractLines(std::vector<Line>& lines)
   {
     it->leastSqFit();
   }
-  if(lines_.size()>1)
+  
+  // If there is more than one line, check if lines should be merged based on the merging criteria
+  if (lines_.size() > 1)
+  {
     mergeLines();
+  }
 
   lines = lines_;
 }

--- a/src/line_extraction.cpp
+++ b/src/line_extraction.cpp
@@ -45,7 +45,8 @@ void LineExtraction::extractLines(std::vector<Line>& lines)
   {
     it->leastSqFit();
   }
-  mergeLines();
+  if(lines_.size()>1)
+    mergeLines();
 
   lines = lines_;
 }


### PR DESCRIPTION
 if there is only one line left before mergeLines(), the line will be removed in mergeLines() function