### PR TITLE
Inlined pi_to_pi to get rid of multiple definition error

### DIFF
--- a/include/laser_line_extraction/utilities.h
+++ b/include/laser_line_extraction/utilities.h
@@ -48,7 +48,10 @@ struct PointParams
   std::vector<double> s;
 };
 
-double pi_to_pi(double angle)
+// Inlining this function will be faster
+// and also get rid of multiple definitions
+// error
+inline double pi_to_pi(double angle)
 {
   angle = fmod(angle, 2 * M_PI);
   if (angle >= M_PI)


### PR DESCRIPTION
The pi_to_pi function was getting defined multiple times during compilation when I linked to laser_line_extraction. To fix this I inlined it so that the code is always replaced by the compiler instead of the standard function call procedure, which should be faster for this small function as well.