### PR TITLE
Fixed timestamp problem, on-demand marker publishing, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,15 @@ Laser Line Extraction subscribes to a single topic and publishes one or two topi
 - `/line_segments` (laser\_line\_extraction/LineSegmentList)
 	- A list of line segments extracted from a laser scan.
 - `/line_markers` ([visualization_msgs/Marker](http://docs.ros.org/api/visualization_msgs/html/msg/Marker.html))
-	- (optional) Markers so that the extracted lines can be visualized in rviz (see above image). Can be toggled (see Parameters).
+	- Markers so that the extracted lines can be visualized in rviz (see above image). Messages are being generated and published when there are at least one subscriber.
 
 ## Parameters
 The parameters are listed in alphabetical order.
 
+- `frequency` (default: 30.0)
+  - The maximum rate of processing LaserScan messages (msg/sec).
 - `bearing_std_dev` (default: 0.001)
 	- The standard deviation of bearing uncertainty in the laser scans (rad).
-- `frame_id` (default: "laser")
-	- The frame in which the line segments are published.
 - `least_sq_angle_thresh` (default: 0.0001)
 	- Change in angle (rad) threshold to stop iterating least squares (`least_sq_radius_thresh` must also be met).
 - `least_sq_radius_thresh` (default: 0.0001)
@@ -73,8 +73,6 @@ The parameters are listed in alphabetical order.
 	- When performing "split" step of split and merge, a split between two points results when the two points are at least this far apart (m).
 - `outlier_dist` (default: 0.05)
 	- Points who are at least this distance from all their neighbours are considered outliers (m).
-- `publish_markers` (default: false)
-	- Whether or not markers are published.
 - `range_std_dev` (default: 0.02)
 	- The standard deviation of range uncertainty in the laser scans (m).
 - `scan_topic` (default: "scan")

--- a/include/laser_line_extraction/line_extraction_ros.h
+++ b/include/laser_line_extraction/line_extraction_ros.h
@@ -22,8 +22,6 @@ public:
   // Constructor / destructor
   LineExtractionROS(ros::NodeHandle&, ros::NodeHandle&);
   ~LineExtractionROS();
-  // Running
-  void run();
 
 private:
   // ROS
@@ -33,9 +31,8 @@ private:
   ros::Publisher line_publisher_;
   ros::Publisher marker_publisher_;
   // Parameters
-  std::string frame_id_;
+  std::unique_ptr<ros::Rate> frequency_;
   std::string scan_topic_;
-  bool pub_markers_;
   // Line extraction
   LineExtraction line_extraction_;
   bool data_cached_; // true after first scan used to cache data

--- a/launch/example.launch
+++ b/launch/example.launch
@@ -3,7 +3,6 @@
     <param name="~frequency" value="30.0" />
     <param name="~frame_id" value="laser" />
     <param name="~scan_topic" value="scan" />
-    <param name="~publish_markers" value="true" />
     <param name="~bearing_std_dev" value="1e-5" />
     <param name="~range_std_dev" value="0.012" />
     <param name="~least_sq_angle_thresh" value="0.0001" />

--- a/launch/example.launch
+++ b/launch/example.launch
@@ -1,7 +1,6 @@
 <launch>
   <node name="line_extractor" pkg="laser_line_extraction" type="line_extraction_node">
     <param name="~frequency" value="30.0" />
-    <param name="~frame_id" value="laser" />
     <param name="~scan_topic" value="scan" />
     <param name="~bearing_std_dev" value="1e-5" />
     <param name="~range_std_dev" value="0.012" />

--- a/src/line_extraction_node.cpp
+++ b/src/line_extraction_node.cpp
@@ -15,18 +15,7 @@ int main(int argc, char **argv)
   ros::NodeHandle nh;
   ros::NodeHandle nh_local("~");
   line_extraction::LineExtractionROS line_extractor(nh, nh_local);
-
-  double frequency;
-  nh_local.param<double>("frequency", frequency, 25);
-  ROS_DEBUG("Frequency set to %0.1f Hz", frequency);
-  ros::Rate rate(frequency);
-
-  while (ros::ok())
-  {
-    line_extractor.run();
-    ros::spinOnce();
-    rate.sleep();
-  }
+  ros::spin();
   return 0;
 }
 

--- a/src/line_extraction_ros.cpp
+++ b/src/line_extraction_ros.cpp
@@ -16,40 +16,12 @@ LineExtractionROS::LineExtractionROS(ros::NodeHandle& nh, ros::NodeHandle& nh_lo
 {
   loadParameters();
   line_publisher_ = nh_.advertise<laser_line_extraction::LineSegmentList>("line_segments", 1);
+  marker_publisher_ = nh_.advertise<visualization_msgs::Marker>("line_markers", 1);
   scan_subscriber_ = nh_.subscribe(scan_topic_, 1, &LineExtractionROS::laserScanCallback, this);
-  if (pub_markers_)
-  {
-    marker_publisher_ = nh_.advertise<visualization_msgs::Marker>("line_markers", 1);
-  }
 }
 
 LineExtractionROS::~LineExtractionROS()
 {
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// Run
-///////////////////////////////////////////////////////////////////////////////
-void LineExtractionROS::run()
-{
-  // Extract the lines
-  std::vector<Line> lines;
-  line_extraction_.extractLines(lines);
-
-  // Populate message
-  laser_line_extraction::LineSegmentList msg;
-  populateLineSegListMsg(lines, msg);
-  
-  // Publish the lines
-  line_publisher_.publish(msg);
-
-  // Also publish markers if parameter publish_markers is set to true
-  if (pub_markers_)
-  {
-    visualization_msgs::Marker marker_msg;
-    populateMarkerMsg(lines, marker_msg);
-    marker_publisher_.publish(marker_msg);
-  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -63,20 +35,16 @@ void LineExtractionROS::loadParameters()
 
   // Parameters used by this node
   
-  std::string frame_id, scan_topic;
-  bool pub_markers;
-
-  nh_local_.param<std::string>("frame_id", frame_id, "laser");
-  frame_id_ = frame_id;
-  ROS_DEBUG("frame_id: %s", frame_id_.c_str());
+  std::string scan_topic;
+  double frequency;
 
   nh_local_.param<std::string>("scan_topic", scan_topic, "scan");
   scan_topic_ = scan_topic;
   ROS_DEBUG("scan_topic: %s", scan_topic_.c_str());
 
-  nh_local_.param<bool>("publish_markers", pub_markers, false);
-  pub_markers_ = pub_markers;
-  ROS_DEBUG("publish_markers: %s", pub_markers ? "true" : "false");
+  nh_local_.param<double>("frequency", frequency, 25);
+  ROS_DEBUG("Frequency set to %0.1f Hz", frequency);
+  frequency_ = std::make_unique<ros::Rate>(frequency);
 
   // Parameters used by the line extraction algorithm
 
@@ -147,8 +115,6 @@ void LineExtractionROS::populateLineSegListMsg(const std::vector<Line> &lines,
     line_msg.end = cit->getEnd(); 
     line_list_msg.line_segments.push_back(line_msg);
   }
-  line_list_msg.header.frame_id = frame_id_;
-  line_list_msg.header.stamp = ros::Time::now();
 }
 
 void LineExtractionROS::populateMarkerMsg(const std::vector<Line> &lines, 
@@ -175,8 +141,6 @@ void LineExtractionROS::populateMarkerMsg(const std::vector<Line> &lines,
     p_end.z = 0;
     marker_msg.points.push_back(p_end);
   }
-  marker_msg.header.frame_id = frame_id_;
-  marker_msg.header.stamp = ros::Time::now();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -214,6 +178,27 @@ void LineExtractionROS::laserScanCallback(const sensor_msgs::LaserScan::ConstPtr
 
   std::vector<double> scan_ranges_doubles(scan_msg->ranges.begin(), scan_msg->ranges.end());
   line_extraction_.setRangeData(scan_ranges_doubles);
+
+  // Extract the lines
+  std::vector<Line> lines;
+  line_extraction_.extractLines(lines);
+
+  // Populate message and publish the lines
+  laser_line_extraction::LineSegmentList msg;
+  populateLineSegListMsg(lines, msg);
+  msg.header = scan_msg->header;
+  line_publisher_.publish(msg);
+
+  // Also publish markers if someone is subscribed
+  if (marker_publisher_.getNumSubscribers() > 0)
+  {
+    visualization_msgs::Marker marker_msg;
+    populateMarkerMsg(lines, marker_msg);
+    marker_msg.header = scan_msg->header;
+    marker_publisher_.publish(marker_msg);
+  }
+
+  frequency_->sleep();
 }
 
 } // namespace line_extraction

--- a/src/line_extraction_ros.cpp
+++ b/src/line_extraction_ros.cpp
@@ -42,7 +42,7 @@ void LineExtractionROS::loadParameters()
   scan_topic_ = scan_topic;
   ROS_DEBUG("scan_topic: %s", scan_topic_.c_str());
 
-  nh_local_.param<double>("frequency", frequency, 25);
+  nh_local_.param<double>("frequency", frequency, 30);
   ROS_DEBUG("Frequency set to %0.1f Hz", frequency);
   frequency_ = std::make_unique<ros::Rate>(frequency);
 


### PR DESCRIPTION
Hello there,

I found several issues in your code and fixed them:

- Output timestamps must be equal to the input laser scan timestamp. Because some computers may be slow and some others may be faster. This will be important for some nodes (e.g. SLAM based on line segments). 
- RViz Marker publishing topic is now working on-demand. Adding parameters for visualization topics is not needed. When there are no subscribers, no CPU resources will be used for these markers.
- "frequency" parameter was a bit weird. If the laser scan arrives at 10hz but frequency is 25, line segments are being published at 25hz. This is not a good thing for nodes with heavy algorithms using line segments as inputs. I have modified the code and now the "frequency" parameter works as the maximum rate of processing inputs.
